### PR TITLE
Make safety checks optional and add nix-buffer-with-string

### DIFF
--- a/nix-buffer.el
+++ b/nix-buffer.el
@@ -106,7 +106,9 @@ LISP-FILE The file in question."
   "Load the result of a ‘nix-buffer’ build, checking for safety.
 EXPR-FILE The nix expression being built.
 
-OUT The build result."
+OUT The build result.
+
+SKIP-SAFETY whether to skip safety checks."
   (when (or skip-safety
 	    (gethash out nix-buffer--trusted-exprs)
 	    (nix-buffer--query-safety expr-file out))
@@ -157,9 +159,11 @@ EVENT The process status change event string."
 
 (defun nix-buffer--nix-build (expr-file &optional root skip-safety)
   "Start the nix build.
+EXPR-FILE The file containing the nix expression to build.
+
 ROOT The path we started from.
 
-EXPR-FILE The file containing the nix expression to build."
+SKIP-SAFETY whether to skip the safety checks."
   (let* ((state-dir (f-join nix-buffer-directory-name
 			    (nix-buffer--unique-filename (or root
 							     default-directory))))
@@ -195,12 +199,12 @@ EXPR-FILE The file containing the nix expression to build."
   :type '(string))
 
 ;;;###autoload
-(defun nix-buffer-with-string (string)
-  "Start ‘nix-buffer’ but with a string expression."
+(defun nix-buffer-with-string (expression)
+  "Start ‘nix-buffer’ but with a string EXPRESSION."
   (interactive)
   (let ((expr-file (make-temp-file "nix-buffer")))
     (with-temp-file expr-file
-      (insert string))
+      (insert expression))
     (nix-buffer--nix-build expr-file nil t)))
 
 ;;;###autoload

--- a/nix-buffer.el
+++ b/nix-buffer.el
@@ -166,7 +166,7 @@ ROOT The path we started from.
 SKIP-SAFETY whether to skip the safety checks."
   (let* ((state-dir (f-join nix-buffer-directory-name
 			    (nix-buffer--unique-filename (or root
-							     default-directory))))
+							     buffer-file-name))))
 	 (out-link (f-join state-dir "result"))
 	 (current-out (file-symlink-p out-link))
 	 (err (generate-new-buffer " nix-buffer-nix-build-stderr"))

--- a/nix-buffer.el
+++ b/nix-buffer.el
@@ -201,7 +201,7 @@ SKIP-SAFETY whether to skip the safety checks."
 ;;;###autoload
 (defun nix-buffer-with-string (expression)
   "Start ‘nix-buffer’ but with a string EXPRESSION."
-  (interactive)
+  (interactive "sNix expression: ")
   (let ((expr-file (make-temp-file "nix-buffer")))
     (with-temp-file expr-file
       (insert expression))

--- a/nix-buffer.el
+++ b/nix-buffer.el
@@ -102,12 +102,13 @@ LISP-FILE The file in question."
 (defvar nix-buffer-after-load-hook nil
   "Hook run after ‘nix-buffer’ loads an expression.")
 
-(defun nix-buffer--load-result (expr-file out)
+(defun nix-buffer--load-result (expr-file out &optional skip-safety)
   "Load the result of a ‘nix-buffer’ build, checking for safety.
 EXPR-FILE The nix expression being built.
 
 OUT The build result."
-  (when (or (gethash out nix-buffer--trusted-exprs)
+  (when (or skip-safety
+	    (gethash out nix-buffer--trusted-exprs)
 	    (nix-buffer--query-safety expr-file out))
     (load out t t nil t)
     (run-hooks 'nix-buffer-after-load-hook)))
@@ -138,7 +139,7 @@ EVENT The process status change event string."
 		  (ignore-errors (delete-file out-link))
 		(unless (string= last-out cur-out)
 		  (with-current-buffer user-buf
-		    (nix-buffer--load-result expr-file cur-out)))))
+		    (nix-buffer--load-result expr-file cur-out nil)))))
 	  (with-current-buffer
 	      (get-buffer-create "*nix-buffer errors*")
 	    (insert "nix-build for nix-buffer for "
@@ -181,7 +182,7 @@ EXPR-FILE The file containing the nix expression to build."
 				err)
      :stderr err)
     (when current-out
-      (nix-buffer--load-result expr-file current-out))))
+      (nix-buffer--load-result expr-file current-out nil))))
 
 (defcustom nix-buffer-root-file "dir-locals.nix"
   "File name to use for determining Nix expression to use."


### PR DESCRIPTION
By default safety checks are still performed. However, they are not performed when using nix-buffer-string because it is intended to be evaluated directly.

---
A question on the safety of nix-build though:

Is there a security concern with running arbitrary nix-build give that we have enabled:
- multi-user mode
- sandboxing
?

It seems to me that nix-build should be safe to run by design (I guess it could eat up resources though).